### PR TITLE
Feature/additional interval union constructors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ julia> cardinal(I)
 4
 julia> complement(I)
 ]-Inf,0[ ∪ ]1,2[ ∪ [4,4] ∪ [5,Inf[
-julia> J = IntervalUnion([Interval(0.5,true,4)])
+julia> J = IntervalUnion(0.5,true,4)
 ]0.5,4]
 julia> I ∪ J
 [0,5[

--- a/docs/src/intervalunions.md
+++ b/docs/src/intervalunions.md
@@ -6,15 +6,17 @@ The type `IntervalUnion` implements unions of disjoint `Intervals` of real numbe
 
 ### Definition
 
-An `IntervalUnion` is simply an array of `Intervals`. The `Intervals` given to the constructor can be in any order and may overlap, they will be merged and ordered by the constructor:
+An `IntervalUnion` is simply an array of `Intervals`. The `Intervals` given to the constructor can be in any order and may overlap, they will be merged and ordered by the constructor. For `IntervalUnions` with only a single `Interval`, simplified constructors can be used to pass the `Interval` arguments directly:
 
 ```julia
-julia> i = IntervalUnion([Interval(0,1)])
+julia> i = IntervalUnion(0,1)
 [0,1]
 julia> j = IntervalUnion([Interval(0,1,true),Interval(1,true,3,true)])
 [0,1[ ∪ ]1,3[
 julia> k = IntervalUnion([Interval(4.3,true,5),Interval(0,1,true),Interval(-2,0.3,true),Interval(1,true,3,true)])
 [-2,1[ ∪ ]1,3[ ∪ ]4.3,5]
+julia> l = IntervalUnion(-2,true,2,true)
+]-2,2[
 ```
 
 As for `Intervals`, an empty union of `Intervals` can be created with:
@@ -127,15 +129,15 @@ julia> i ∪ IntervalUnion()
 It is possible to compute the complement of `IntervalUnions`:
 
 ```julia
-julia> i = IntervalUnion([Interval(0,1)])
+julia> i = IntervalUnion(0,1)
 [0,1]
 julia> complement(i)
 ]-Inf,0[ ∪ ]1,Inf[
-julia> j = IntervalUnion([Interval(0,0)])
+julia> j = IntervalUnion(0,0)
 [0,0]
 julia> complement(j)
 ]-Inf,0[ ∪ ]0,Inf[
-julia> k = IntervalUnion([Interval(0,true,0,true)])
+julia> k = IntervalUnion(0,true,0,true)
 ]0,0[
 julia> complement(k)
 ]-Inf,Inf[

--- a/src/base.jl
+++ b/src/base.jl
@@ -754,6 +754,64 @@ function IntervalUnion()
 end
 
 """
+	IntervalUnion(left,right)
+
+Simplified constructor for `IntervalUnions` with only one `Interval` closed on both side.
+Ex:
+```
+julia> i = IntervalUnion(2,3)
+[2,3]
+"""
+function IntervalUnion(left::Real, right::Real)
+	IntervalUnion([Interval(left,right)])
+end
+
+"""
+	IntervalUnion(left,open_left,right)
+
+Simplified constructor for `IntervalUnions` with only one `Interval` closed on the right side.
+Ex:
+```
+julia> i = IntervalUnion(2,true,3)
+]2,3]
+julia> i = IntervalUnion(2,false,3)
+[2,3]
+"""
+function IntervalUnion(left::Real, open_left::Bool, right::Real)
+	IntervalUnion([Interval(left,open_left,right)])
+end
+
+"""
+	IntervalUnion(left,right,open_right)
+
+Simplified constructor for `IntervalUnions` with only one `Interval` closed on the left side.
+Ex:
+```
+julia> i = IntervalUnion(2,3,true)
+[2,3[
+julia> i = IntervalUnion(2,3,false)
+[2,3]
+"""
+function IntervalUnion(left::Real, right::Real, open_right::Bool)
+	IntervalUnion([Interval(left,right,open_right)])
+end
+
+"""
+	IntervalUnion(left,open_left,right,open_right)
+
+Simplified constructor for `IntervalUnions` with only one `Interval`.
+Ex:
+```
+julia> i = IntervalUnion(2,true,3,true)
+]2,3[
+julia> i = IntervalUnion(2,false,3,false)
+[2,3]
+"""
+function IntervalUnion(left::Real, open_left::Bool, right::Real, open_right::Bool)
+	IntervalUnion([Interval(left,open_left,right,open_right)])
+end
+
+"""
 	empty(iu)
 
 Returns true if the given `IntervalUnion` is empty.

--- a/test/intervalunions.jl
+++ b/test/intervalunions.jl
@@ -35,15 +35,35 @@ J = IntervalUnion([Interval(0,1),Interval(3,true,5)])
 
 # I = [0,1]
 I = IntervalUnion([Interval(0,1)])
+II = IntervalUnion(0,1)
+@test I == II 
 @test string(I) == "[0,1]"
+@test string(II) == "[0,1]"
 
 # J = ]1,2.5]
 J = IntervalUnion([Interval(1,true,2.5)])
+JJ = IntervalUnion(1,true,2.5)
+@test J == JJ
 @test string(J) == "]1,2.5]"
+@test string(JJ) == "]1,2.5]"
 
 # K = ]0,1[ ∪ ]1,2.6] ∪ [2.7,4]
 K = IntervalUnion([Interval(0,true,1,true),Interval(1,true,2.6),Interval(2.7,4)])
 @test string(K) == "]0,1[ ∪ ]1,2.6] ∪ [2.7,4]"
+
+# L = [-1,-0.998[
+L = IntervalUnion([Interval(-1,-0.998,true)])
+LL = IntervalUnion(-1,-0.998,true)
+@test L == LL
+@test string(L) == "[-1,-0.998["
+@test string(LL) == "[-1,-0.998["
+
+# L = ]-2.3,1.67[
+M = IntervalUnion([Interval(-2.3,true,1.67,true)])
+MM = IntervalUnion(-2.3,true,1.67,true)
+@test M == MM
+@test string(M) == "]-2.3,1.67["
+@test string(MM) == "]-2.3,1.67["
 
 # Tests for equality
 @test I == I


### PR DESCRIPTION
Add new constructors for `IntervalUnions` with a single `Interval`. The `Interval` arguments are passed directly.